### PR TITLE
fix: typo on Cappuccino

### DIFF
--- a/src/components/pages/ListPage.vue
+++ b/src/components/pages/ListPage.vue
@@ -61,7 +61,7 @@ export default defineComponent({
       translation: {
         'Espresso': '特浓咖啡',
         'Espresso Macchiato': '浓缩玛奇朵',
-        'Cappucino': '卡布奇诺',
+        'Cappuccino': '卡布奇诺',
         'Mocha': '摩卡',
         'Flat White': '平白咖啡',
         'Americano': '美式咖啡',


### PR DESCRIPTION
Double click on Cappuccino will be blank. Because of `src/components/pages/ListPage.vue` have to change to be **Cappuccino** also.

```
        'Cappucino': '卡布奇诺',
```

https://github.com/jecfish/coffee-cart/blob/main/src/components/pages/ListPage.vue#L64 

