### PR TITLE
Fix documentation typo for `ad` URL param

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://coffee-cart.app/. This demo created with Vue 3 + Typescript + Vite.
 3. [Desktop only] **Hover** over Pay button will show a quick cart preview, click to add or remove items.
 4. A random promo coffee pop up show up when adding every 3rd items to the cart. (e.g. 3, 6, 9, ...)
 5. The add to cart process will be slowing down (intentionally) when the cart has more than 7 items.
-6. Slow down page load performance with ads by passing in an `ads` param (e.g. https://coffee-cart.app/?ad=1).
+6. Slow down page load performance with ads by passing in an `ad` param (e.g. https://coffee-cart.app/?ad=1).
 
 ## To run it with slow performance
 

--- a/src/components/pages/GitHubPage.vue
+++ b/src/components/pages/GitHubPage.vue
@@ -8,7 +8,7 @@
       <li>[Desktop only] Hover over Pay button will show a quick cart preview, click to add or remove items.</li>
       <li>A random promo coffee pop up show up when adding every 3rd items to the cart. (e.g. 3, 6, 9, ...)</li>
       <li>The add to cart process will be slowing down (intentionally) when the cart has more than 7 items.</li>
-      <li>Slow down page load performance with ads by passing in an <code>ads</code> param. <a href="https://coffee-cart.app/?ad=1">https://coffee-cart.app/?ad=1</a></li>
+      <li>Slow down page load performance with ads by passing in an <code>ad</code> param. <a href="https://coffee-cart.app/?ad=1">https://coffee-cart.app/?ad=1</a></li>
       <li>Simulate throw an error when adding coffee to cart. <a href="https://coffee-cart.app/?breakable=1">https://coffee-cart.app/?breakable=1</a></li>
    
     </ul>


### PR DESCRIPTION
Crucial fix for documentation comprehension. I was confused for hours